### PR TITLE
[bugfix] fix grinding stacks of items

### DIFF
--- a/Content.Server/_tc14/Tools/Systems/GrindOnDoAfterSystem.cs
+++ b/Content.Server/_tc14/Tools/Systems/GrindOnDoAfterSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared._tc14.Tools.Components;
+﻿using Content.Server.Stack;
+using Content.Shared._tc14.Tools.Components;
 using Content.Shared._tc14.Tools.Systems;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
@@ -18,7 +19,7 @@ public sealed class GrindOnDoAfterSystem : EntitySystem
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly SharedPopupSystem _popups = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly StackSystem _stack = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -40,9 +41,10 @@ public sealed class GrindOnDoAfterSystem : EntitySystem
             return;
 
         var solution = solutionEnt.Value.Comp.Solution;
+        var scale = _stack.GetCount(item.Value);
+        solution.ScaleSolution(scale);
         _solution.TryGetSolution(uid, component.Solution, out var target);
-        _solution.TryAddSolution(target!.Value, solution);
-
+        _solution.ForceAddSolution(target!.Value, solution);
         QueueDel(item);
         _popups.PopupClient(Loc.GetString("grind-grinded"), args.User);
     }

--- a/Resources/Prototypes/_tc14/Entities/Objects/Tools/stone.yml
+++ b/Resources/Prototypes/_tc14/Entities/Objects/Tools/stone.yml
@@ -100,7 +100,7 @@
   - type: SolutionContainerManager
     solutions:
       mortar:
-        maxVol: 25
+        maxVol: 50
   - type: MixableSolution
     solution: mortar
   - type: RefillableSolution


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## What was changed in this PR? What goals are you trying to achieve with these changes?
Mortar now accounts for item stacks correctly (reported by Beridot on discord, thanks!)
Mortar volume: 25u -> 50u.
## Please provide technical details to the implementation of this feature, if it's complex enough.
awa
## Please attach the media showcasing the feature.
nah
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have read and am following the [TC14 Conventions](https://wiki.tc14.space/Conventions)

**Changelog**
:cl:
- tweak: Mortar volume has been changed from 25u to 50u.
- fix: Mortars correctly grind item stacks.
